### PR TITLE
Add support for specifying Bicep version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Bicep Lint Action
+
 GitHub Action to lint [Bicep](https://github.com/Azure/bicep). This will show the linting messages in both the pull requests and the actions workflow runs. You are also able to set your own [Bicep linter configuration](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config-linter) which this action will respect.
 
 ## Input Configuration Options
+
 analyse-all-files
+
 - **Description**: Used to determine whether you just want to analyse the files changed or the whole repository. When set to false on a pull request event, it will compare between the current and target branch. When set to false on a push event, it will compare the changes between two commits.
 - **Required**: false
 - **Default**: 'false'
 
+bicep-version
+
+- **Description**: Bicep version used to build files. Specific versions can be found with 'az bicep list-versions' Defaults to latest.
+- **Required:**: false
+- **Default:**: 'latest'
+
 ## Example Workflow File
-```
+
+```yaml
 name: Linter
 on:
   pull_request:
@@ -19,13 +29,14 @@ jobs:
     name: Bicep
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-      with:
-        # Incremental diffs require fetch depth to be at 0 to grab the target branch
-        fetch-depth: '0'
-    - name: Run Bicep Linter
-      uses: synergy-au/bicep-lint-action@v1
-      with:
-        analyse-all-files: 'true'
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          # Incremental diffs require fetch depth to be at 0 to grab the target branch
+          fetch-depth: "0"
+      - name: Run Bicep Linter
+        uses: synergy-au/bicep-lint-action@v1
+        with:
+          analyse-all-files: "true" # optional, defaults to false (only analyse changed files)
+          bicep-version: "latest" # optional, defaults to latest
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,20 @@
-name: 'Bicep Linter'
-description: 'Runs Bicep build on the files, takes any linting errors and surfaces them in GitHub'
+name: "Bicep Linter"
+description: "Runs Bicep build on the files, takes any linting errors and surfaces them in GitHub"
 branding:
-  icon: 'zoom-in'  
-  color: 'yellow'
+  icon: "zoom-in"
+  color: "yellow"
 inputs:
   analyse-all-files:
-    description: 'Used to determine whether you just want to analyse the files changed or the whole repository.'
+    description: "Used to determine whether you just want to analyse the files changed or the whole repository."
     required: false
-    default: 'false'
+    default: "false"
+  bicep-version:
+    description: "Bicep version used to build files. Specific versions can be found with 'az bicep list-versions' Defaults to latest."
+    required: false
+    default: "latest"
 runs:
   using: "composite"
-  steps: 
+  steps:
     - id: code
       run: |
         if [ ${{ github.event_name }} == 'pull_request' ]; then
@@ -30,3 +34,4 @@ runs:
         CHANGED_CODE: ${{ steps.code.outputs.changed_code }}
         WORKSPACE: ${{ github.workspace }}/
         ACTION_EVENT_NAME: ${{ github.event_name }}
+        BICEP_VERSION: ${{ inputs.bicep-version }}

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,11 @@ runs:
     - id: code
       run: |
         if [ ${{ github.event_name }} == 'pull_request' ]; then
-            echo "::set-output name=current_code::${{ github.base_ref }}"
-            echo "::set-output name=changed_code::${{ github.head_ref }}"
+            echo "current_code=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+            echo "changed_code=${{ github.head_ref }}" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=current_code::${{ github.event.before }}"
-            echo "::set-output name=changed_code::${{ github.event.after }}"
+            echo "current_code=${{ github.event.before }}" >> $GITHUB_OUTPUT
+            echo "changed_code=${{ github.event.after }}" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - id: bicep-linter

--- a/bicep-lint.sh
+++ b/bicep-lint.sh
@@ -1,7 +1,12 @@
 # shellcheck shell=sh disable=SC3011,SC3014
 
 ## Download Azure CLI
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+if ! command -v az > /dev/null 2>&1
+then
+    echo "Azure CLI not found - installing..."
+    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    exit
+fi
 
 ## Install Bicep CLI
 if [ "$BICEP_VERSION" != 'latest' ]; then

--- a/bicep-lint.sh
+++ b/bicep-lint.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=sh
+# shellcheck shell=sh disable=SC3011,SC3014
 
 ## Download Azure CLI
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/bicep-lint.sh
+++ b/bicep-lint.sh
@@ -54,6 +54,8 @@ while read -r message; do
         echo "::notice file=$FILENAME,line=$LINE,col=$COLUMN,title=$TITLE::$MESSAGE"
     elif [ "$SEVERITY" == 'Error' ]; then
         echo "::error file=$FILENAME,line=$LINE,col=$COLUMN,title=$TITLE::$MESSAGE"
+    elif expr "$MESSAGE" : "az bicep upgrade" > /dev/null; then
+        true # do not add upgrade prompts
     else
         echo "::warning file=$FILENAME,line=$LINE,col=$COLUMN,title=$TITLE::$MESSAGE"
     fi

--- a/bicep-lint.sh
+++ b/bicep-lint.sh
@@ -3,6 +3,13 @@
 ## Download Azure CLI
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
+## Install Bicep CLI
+if [ "$BICEP_VERSION" != 'latest' ]; then
+    az bicep install -v "$BICEP_VERSION"
+else
+    az bicep install
+fi
+
 # Now either run the full analysis or files changed based on the settings defined
 if [ "$ANALYSE_ALL_FILES" == 'true' ]; then
     while read -r file; do


### PR DESCRIPTION
Since build results will vary across versions this adds the option to
specify version. The default version is the latest available version.

This is motivated by the release cadence of Bicep versions and wanting
to test for specific or multiple versions.

Other fixes:

- Remove deprecated set-output syntax (78e50b5ef320f0ee754d1818bffe452ea8390d3d)
- Do not install az if it's already installed (0b3c0e2b2f645c0324d25daa27cdc26b8eec3d2d)
- Add shellcheck disabled rules (only for existing warnings) 70ddeafde19dc0b04f9e4463e3f28c3fc206ac4c